### PR TITLE
Upgrade qulice to 0.27.6 and grizzly to 5.0.1

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 21]
+        java: [21]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <dependency>
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-servlet-server</artifactId>
-      <version>4.0.2</version>
+      <version>5.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -214,7 +214,7 @@
         <plugin>
           <groupId>com.qulice</groupId>
           <artifactId>qulice-maven-plugin</artifactId>
-          <version>0.25.1</version>
+          <version>0.27.6</version>
           <configuration>
             <excludes combine.children="append">
               <exclude>findbugs:.*</exclude>

--- a/src/main/java/co/stateful/Atomic.java
+++ b/src/main/java/co/stateful/Atomic.java
@@ -47,6 +47,11 @@ import lombok.ToString;
 public final class Atomic<T> implements Callable<T> {
 
     /**
+     * Default maximum waiting time, in milliseconds (five minutes).
+     */
+    private static final long DEFAULT_MAX = TimeUnit.MINUTES.toMillis(5L);
+
+    /**
      * Random.
      */
     private static final Random RANDOM = new SecureRandom();
@@ -92,7 +97,7 @@ public final class Atomic<T> implements Callable<T> {
      * @param lbl Label to use for locking and unlocking (can be empty)
      */
     public Atomic(final Callable<T> clbl, final Lock lck, final String lbl) {
-        this(clbl, lck, lbl, TimeUnit.MINUTES.toMillis(5L));
+        this(clbl, lck, lbl, Atomic.DEFAULT_MAX);
     }
 
     // @checkstyle ParameterNumberCheck (15 lines)
@@ -184,5 +189,4 @@ public final class Atomic<T> implements Callable<T> {
             throw new IllegalStateException(ex);
         }
     }
-
 }

--- a/src/main/java/co/stateful/Counter.java
+++ b/src/main/java/co/stateful/Counter.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Counter.
- *
  * @since 0.1
  */
 @Immutable
@@ -36,5 +35,4 @@ public interface Counter {
      * @throws IOException If some I/O problem
      */
     long incrementAndGet(long delta) throws IOException;
-
 }

--- a/src/main/java/co/stateful/Counters.java
+++ b/src/main/java/co/stateful/Counters.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Counters.
- *
  * @since 0.1
  */
 @Immutable
@@ -44,5 +43,4 @@ public interface Counters {
      * @throws IOException If some I/O problem
      */
     Counter get(String name) throws IOException;
-
 }

--- a/src/main/java/co/stateful/Lock.java
+++ b/src/main/java/co/stateful/Lock.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Lock.
- *
  * @since 0.3
  */
 @Immutable
@@ -47,5 +46,4 @@ public interface Lock {
      * @since 0.11
      */
     boolean unlock(String label) throws IOException;
-
 }

--- a/src/main/java/co/stateful/Locks.java
+++ b/src/main/java/co/stateful/Locks.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 
 /**
  * Locks.
- *
  * @since 0.2
  */
 @Immutable
@@ -31,5 +30,4 @@ public interface Locks {
      * @throws IOException If fails
      */
     Lock get(String name) throws IOException;
-
 }

--- a/src/main/java/co/stateful/RtCounter.java
+++ b/src/main/java/co/stateful/RtCounter.java
@@ -19,7 +19,6 @@ import lombok.ToString;
 
 /**
  * Counter.
- *
  * @since 0.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
@@ -28,6 +27,13 @@ import lombok.ToString;
 @ToString(of = "label", includeFieldNames = false)
 @EqualsAndHashCode(of = { "label", "request" })
 final class RtCounter implements Counter {
+
+    /**
+     * XPath template to a counter operation link.
+     * @checkstyle LineLength (3 lines)
+     */
+    private static final String XPATH =
+        "/page/counters/counter[name='%s']/links/link[@rel='%s']/@href";
 
     /**
      * Its name.
@@ -95,13 +101,6 @@ final class RtCounter implements Counter {
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(XmlResponse.class)
-            .rel(
-                String.format(
-                    // @checkstyle LineLength (1 line)
-                    "/page/counters/counter[name='%s']/links/link[@rel='%s']/@href",
-                    this.label, ops
-                )
-            );
+            .rel(String.format(RtCounter.XPATH, this.label, ops));
     }
-
 }

--- a/src/main/java/co/stateful/RtCounters.java
+++ b/src/main/java/co/stateful/RtCounters.java
@@ -19,7 +19,6 @@ import lombok.ToString;
 
 /**
  * Counters.
- *
  * @since 0.1
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
@@ -28,6 +27,13 @@ import lombok.ToString;
 @ToString(of = { })
 @EqualsAndHashCode(of = "request")
 final class RtCounters implements Counters {
+
+    /**
+     * XPath template to a counter delete link.
+     * @checkstyle LineLength (3 lines)
+     */
+    private static final String XPATH_DELETE =
+        "/page/counters/counter[name='%s']/links/link[@rel='delete']/@href";
 
     /**
      * Entry request.
@@ -81,13 +87,7 @@ final class RtCounters implements Counters {
             .as(RestResponse.class)
             .assertStatus(HttpURLConnection.HTTP_OK)
             .as(XmlResponse.class)
-            .rel(
-                String.format(
-                    // @checkstyle LineLength (1 line)
-                    "/page/counters/counter[name='%s']/links/link[@rel='delete']/@href",
-                    name
-                )
-            )
+            .rel(String.format(RtCounters.XPATH_DELETE, name))
             .header(HttpHeaders.ACCEPT, MediaType.TEXT_XML)
             .uri().queryParam("name", name).back()
             .fetch()

--- a/src/main/java/co/stateful/RtLock.java
+++ b/src/main/java/co/stateful/RtLock.java
@@ -20,7 +20,6 @@ import lombok.ToString;
 
 /**
  * Lock.
- *
  * @since 0.3
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
@@ -111,5 +110,4 @@ final class RtLock implements Lock {
             .as(XmlResponse.class)
             .rel(String.format("/page/links/link[@rel='%s']/@href", label));
     }
-
 }

--- a/src/main/java/co/stateful/RtLocks.java
+++ b/src/main/java/co/stateful/RtLocks.java
@@ -18,7 +18,6 @@ import lombok.ToString;
 
 /**
  * Locks.
- *
  * @since 0.2
  * @checkstyle MultipleStringLiteralsCheck (500 lines)
  */
@@ -58,5 +57,4 @@ final class RtLocks implements Locks {
     public Lock get(final String name) {
         return new RtLock(name, this.request);
     }
-
 }

--- a/src/main/java/co/stateful/RtSttc.java
+++ b/src/main/java/co/stateful/RtSttc.java
@@ -67,32 +67,16 @@ public final class RtSttc implements Sttc {
      * @param token Security token
      */
     public RtSttc(final URN urn, final String token) {
-        this.request = new JdkRequest("https://www.stateful.co")
-            .through(OneMinuteWire.class)
-            .through(RetryWire.class)
-            .through(VerboseWire.class)
-            .through(CachingWire.class, "((POST|PUT|PATCH) .*|.*\\?.*)")
-            .header("X-Sttc-URN", urn.toString())
-            .header("X-Sttc-Token", token)
-            .header(HttpHeaders.ACCEPT, MediaType.TEXT_XML)
-            .header(HttpHeaders.USER_AGENT, "java-sdk.stateful.co");
+        // @checkstyle ConstructorsCodeFreeCheck (1 line)
+        this(RtSttc.entry(urn, token));
     }
 
     /**
-     * Make an instance of it.
-     * @param urn Owner URN
-     * @param token Security token
-     * @return Sttc
+     * Ctor.
+     * @param req Entry request
      */
-    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
-    public static Sttc make(final URN urn, final String token) {
-        final Sttc sttc;
-        if (token.matches("[A-F0-9\\-]{19}")) {
-            sttc = new RtSttc(urn, token);
-        } else {
-            sttc = new MkSttc();
-        }
-        return sttc;
+    private RtSttc(final Request req) {
+        this.request = req;
     }
 
     @Override
@@ -117,5 +101,40 @@ public final class RtSttc implements Sttc {
                 .as(XmlResponse.class)
                 .rel("/page/links/link[@rel='menu:locks']/@href")
         );
+    }
+
+    /**
+     * Make an instance of it.
+     * @param urn Owner URN
+     * @param token Security token
+     * @return Sttc
+     */
+    @SuppressWarnings("PMD.ProhibitPublicStaticMethods")
+    public static Sttc make(final URN urn, final String token) {
+        final Sttc sttc;
+        if (token.matches("[A-F0-9\\-]{19}")) {
+            sttc = new RtSttc(urn, token);
+        } else {
+            sttc = new MkSttc();
+        }
+        return sttc;
+    }
+
+    /**
+     * Build entry request.
+     * @param urn Owner URN
+     * @param token Security token
+     * @return Request
+     */
+    private static Request entry(final URN urn, final String token) {
+        return new JdkRequest("https://www.stateful.co")
+            .through(OneMinuteWire.class)
+            .through(RetryWire.class)
+            .through(VerboseWire.class)
+            .through(CachingWire.class, "((POST|PUT|PATCH) .*|.*\\?.*)")
+            .header("X-Sttc-URN", urn.toString())
+            .header("X-Sttc-Token", token)
+            .header(HttpHeaders.ACCEPT, MediaType.TEXT_XML)
+            .header(HttpHeaders.USER_AGENT, "java-sdk.stateful.co");
     }
 }

--- a/src/main/java/co/stateful/Sttc.java
+++ b/src/main/java/co/stateful/Sttc.java
@@ -42,5 +42,4 @@ public interface Sttc {
      * @throws IOException If some I/O problem
      */
     Locks locks() throws IOException;
-
 }

--- a/src/main/java/co/stateful/cached/CdCounters.java
+++ b/src/main/java/co/stateful/cached/CdCounters.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Cached counters.
- *
  * @since 0.7
  */
 @Immutable

--- a/src/main/java/co/stateful/cached/CdLocks.java
+++ b/src/main/java/co/stateful/cached/CdLocks.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Cached locks.
- *
  * @since 0.7
  */
 @Immutable

--- a/src/main/java/co/stateful/cached/CdSttc.java
+++ b/src/main/java/co/stateful/cached/CdSttc.java
@@ -17,7 +17,6 @@ import lombok.ToString;
 
 /**
  * Cached Sttc.
- *
  * @since 0.7
  */
 @Immutable

--- a/src/main/java/co/stateful/cached/package-info.java
+++ b/src/main/java/co/stateful/cached/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * Cached SDK interfaces (highly recommended to use in production).
- *
  * @since 0.7
  */
 package co.stateful.cached;

--- a/src/main/java/co/stateful/mock/MkCounter.java
+++ b/src/main/java/co/stateful/mock/MkCounter.java
@@ -12,7 +12,6 @@ import lombok.ToString;
 
 /**
  * Mock counter.
- *
  * @since 0.1
  */
 @Immutable

--- a/src/main/java/co/stateful/mock/MkCounters.java
+++ b/src/main/java/co/stateful/mock/MkCounters.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Mock counters.
- *
  * @since 0.1
  */
 @Immutable
@@ -42,5 +41,4 @@ final class MkCounters implements Counters {
     public Counter get(final String name) {
         return new MkCounter();
     }
-
 }

--- a/src/main/java/co/stateful/mock/MkLock.java
+++ b/src/main/java/co/stateful/mock/MkLock.java
@@ -12,7 +12,6 @@ import lombok.ToString;
 
 /**
  * Mock lock.
- *
  * @since 0.3
  */
 @Immutable

--- a/src/main/java/co/stateful/mock/MkLocks.java
+++ b/src/main/java/co/stateful/mock/MkLocks.java
@@ -13,7 +13,6 @@ import lombok.ToString;
 
 /**
  * Mock locks.
- *
  * @since 0.2
  */
 @Immutable
@@ -31,5 +30,4 @@ final class MkLocks implements Locks {
     public Lock get(final String name) {
         return new MkLock();
     }
-
 }

--- a/src/main/java/co/stateful/mock/MkSttc.java
+++ b/src/main/java/co/stateful/mock/MkSttc.java
@@ -14,7 +14,6 @@ import lombok.ToString;
 
 /**
  * Mock.
- *
  * @since 0.1
  */
 @Immutable

--- a/src/main/java/co/stateful/retry/ReCounter.java
+++ b/src/main/java/co/stateful/retry/ReCounter.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 
 /**
  * Retriable counter.
- *
  * @since 0.5
  */
 @Immutable

--- a/src/main/java/co/stateful/retry/ReCounters.java
+++ b/src/main/java/co/stateful/retry/ReCounters.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Retriable counters.
- *
  * @since 0.5
  */
 @Immutable

--- a/src/main/java/co/stateful/retry/ReLock.java
+++ b/src/main/java/co/stateful/retry/ReLock.java
@@ -15,7 +15,6 @@ import lombok.ToString;
 
 /**
  * Retriable lock.
- *
  * @since 0.5
  */
 @Immutable

--- a/src/main/java/co/stateful/retry/ReLocks.java
+++ b/src/main/java/co/stateful/retry/ReLocks.java
@@ -16,7 +16,6 @@ import lombok.ToString;
 
 /**
  * Retriable locks.
- *
  * @since 0.5
  */
 @Immutable

--- a/src/test/java/co/stateful/AtomicTest.java
+++ b/src/test/java/co/stateful/AtomicTest.java
@@ -48,19 +48,17 @@ final class AtomicTest {
     void callsUnlockAfterException() throws Exception {
         final Lock lock = Mockito.mock(Lock.class);
         Mockito.doReturn(true).when(lock).lock(Mockito.anyString());
-        final Atomic<String> atomic = new Atomic<>(
-            () -> {
-                throw new IOException("expected two");
-            },
-            lock
-        );
         org.junit.jupiter.api.Assertions.assertAll(
             () -> org.junit.jupiter.api.Assertions.assertThrows(
                 IOException.class,
-                atomic::call
+                () -> new Atomic<>(
+                    () -> {
+                        throw new IOException("expected two");
+                    },
+                    lock
+                ).call()
             ),
             () -> Mockito.verify(lock).unlock(Mockito.anyString())
         );
     }
-
 }

--- a/src/test/java/co/stateful/RtCounterTest.java
+++ b/src/test/java/co/stateful/RtCounterTest.java
@@ -121,5 +121,4 @@ final class RtCounterTest {
             Matchers.hasItem(MediaType.TEXT_PLAIN)
         );
     }
-
 }

--- a/src/test/java/co/stateful/RtCountersITCase.java
+++ b/src/test/java/co/stateful/RtCountersITCase.java
@@ -21,15 +21,9 @@ final class RtCountersITCase {
      */
     private static final Random RANDOM = new SecureRandom();
 
-    /**
-     * Region rule.
-     * @checkstyle VisibilityModifierCheck (3 lines)
-     */
-    public final transient SttcRule srule = new SttcRule();
-
     @Test
     void incrementsAndSets() throws Exception {
-        final Counters counters = this.srule.get().counters();
+        final Counters counters = SttcRule.fromProperties().get().counters();
         final String name = String.format(
             "test-%s", RtCountersITCase.RANDOM.nextInt(Integer.MAX_VALUE)
         );
@@ -44,5 +38,4 @@ final class RtCountersITCase {
             counters.delete(name);
         }
     }
-
 }

--- a/src/test/java/co/stateful/RtLockTest.java
+++ b/src/test/java/co/stateful/RtLockTest.java
@@ -170,5 +170,4 @@ final class RtLockTest {
             Matchers.hasItem(MediaType.TEXT_XML)
         );
     }
-
 }

--- a/src/test/java/co/stateful/RtLocksITCase.java
+++ b/src/test/java/co/stateful/RtLocksITCase.java
@@ -23,18 +23,12 @@ final class RtLocksITCase {
      */
     private static final Random RANDOM = new SecureRandom();
 
-    /**
-     * Region rule.
-     * @checkstyle VisibilityModifierCheck (3 lines)
-     */
-    public final transient SttcRule srule = new SttcRule();
-
     @Test
     void locksAndUnlocks() throws Exception {
         MatcherAssert.assertThat(
             new Atomic<>(
                 () -> "done",
-                this.srule.get().locks().get(
+                SttcRule.fromProperties().get().locks().get(
                     String.format(
                         "lck-%s",
                         RtLocksITCase.RANDOM.nextInt(Integer.MAX_VALUE)
@@ -47,7 +41,7 @@ final class RtLocksITCase {
 
     @Test
     void locksAndUnlocksInOneThread() throws Exception {
-        final Locks locks = this.srule.get().locks();
+        final Locks locks = SttcRule.fromProperties().get().locks();
         final String name = String.format(
             "test2-%s", RtLocksITCase.RANDOM.nextInt(Integer.MAX_VALUE)
         );
@@ -67,9 +61,8 @@ final class RtLocksITCase {
         Assumptions.assumeFalse(System.getProperty("sttc.urn").isEmpty());
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> this.srule.get().locks()
+            () -> SttcRule.fromProperties().get().locks()
                 .get("invalid name with spaces").lock("test-3")
         );
     }
-
 }

--- a/src/test/java/co/stateful/RtLocksTest.java
+++ b/src/test/java/co/stateful/RtLocksTest.java
@@ -10,7 +10,6 @@ import com.jcabi.http.mock.MkGrizzlyContainer;
 import com.jcabi.http.request.JdkRequest;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -24,14 +23,8 @@ final class RtLocksTest {
     @Test
     void checksExistenceWhenLockPresent() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
-            .next(
-                new MkAnswer.Simple(
-                    StringUtils.join(
-                        "<page><locks><lock><name>замок-αβγ</name>",
-                        "<label>мітка</label></lock></locks></page>"
-                    )
-                )
-            )
+            // @checkstyle LineLength (1 line)
+            .next(new MkAnswer.Simple("<page><locks><lock><name>замок-αβγ</name><label>мітка</label></lock></locks></page>"))
             .start();
         try {
             MatcherAssert.assertThat(
@@ -47,14 +40,8 @@ final class RtLocksTest {
     @Test
     void checksExistenceWhenLockAbsent() throws Exception {
         final MkContainer container = new MkGrizzlyContainer()
-            .next(
-                new MkAnswer.Simple(
-                    StringUtils.join(
-                        "<page><locks><lock><name>другий</name>",
-                        "<label>інша</label></lock></locks></page>"
-                    )
-                )
-            )
+            // @checkstyle LineLength (1 line)
+            .next(new MkAnswer.Simple("<page><locks><lock><name>другий</name><label>інша</label></lock></locks></page>"))
             .start();
         try {
             MatcherAssert.assertThat(
@@ -99,5 +86,4 @@ final class RtLocksTest {
             Matchers.hasItem(MediaType.TEXT_XML)
         );
     }
-
 }

--- a/src/test/java/co/stateful/SttcRule.java
+++ b/src/test/java/co/stateful/SttcRule.java
@@ -27,16 +27,6 @@ final class SttcRule {
 
     /**
      * Ctor.
-     */
-    SttcRule() {
-        this(
-            System.getProperty("sttc.urn"),
-            System.getProperty("sttc.token")
-        );
-    }
-
-    /**
-     * Ctor.
      * @param urn User URN
      * @param tkn Token
      */
@@ -62,4 +52,14 @@ final class SttcRule {
         );
     }
 
+    /**
+     * Make a new SttcRule from system properties.
+     * @return SttcRule
+     */
+    static SttcRule fromProperties() {
+        return new SttcRule(
+            System.getProperty("sttc.urn"),
+            System.getProperty("sttc.token")
+        );
+    }
 }

--- a/src/test/java/co/stateful/package-info.java
+++ b/src/test/java/co/stateful/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * SDK, tests.
- *
  * @since 0.1
  */
 package co.stateful;


### PR DESCRIPTION
@yegor256 — this is ready for merge. All CI checks are green.

Upgrades the build to the current stable plugin/dependency versions and adapts the source to the new linter rules introduced by the upgraded `qulice`.

## Changes

- Bump `qulice-maven-plugin` from `0.25.1` to `0.27.6` (latest stable; supersedes the renovate PR #89, which can't pass CI without the source-code adjustments below).
- Bump `org.glassfish.grizzly:grizzly-http-servlet-server` (test scope) from `4.0.2` to `5.0.1` (latest stable).
- Drop Java 17 from the `mvn` CI matrix. Both qulice 0.27.6 and grizzly 5.0.1 are compiled for Java 21 (class file version 65), so the Java 17 jobs hit `UnsupportedClassVersionError`. This matches the matrix used by other recently-upgraded jcabi projects (e.g. `jcabi/jcabi-velocity`).

## Code adjustments for the new linter rules

Qulice 0.27.6 surfaces several Checkstyle/PMD rules that flagged 60 violations on the existing tree. All of them are fixed in this PR:

- `JavadocEmptyLineBeforeTagCheck` — drop empty `*` lines before `@`-clauses in single-paragraph Javadoc blocks across the codebase.
- `RegexpMultilineCheck` (empty line before closing brace) — remove blank lines that preceded closing braces.
- `ConstructorsCodeFreeCheck` —
  - `RtSttc`: refactor to delegate the public ctor to a private `RtSttc(Request)` ctor, with a `private static entry()` helper that builds the request; suppress the rule on the single `this(RtSttc.entry(...))` delegation line.
  - `Atomic`: replace `TimeUnit.MINUTES.toMillis(5L)` in the ctor delegation with a `DEFAULT_MAX` constant.
  - `SttcRule` (test): replace the no-arg ctor with a `SttcRule.fromProperties()` factory and update call sites.
- `BracketsStructureCheck` / `RegexpSinglelineCheck` (fluent-call rules) — extract long XPath templates in `RtCounter` and `RtCounters` into `private static final String` constants and inline `String.format` into the fluent chain. Inline the XML literals in `RtLocksTest`.
- `ProhibitFieldsInTestClassesCheck` / PMD `PublicMemberInNonPublicType` — drop the public `srule` field from `RtCountersITCase` / `RtLocksITCase` and use `SttcRule.fromProperties()` directly inside each test method.
- PMD `UnnecessaryLocalRule` — inline the temporary local in `AtomicTest#callsUnlockAfterException`.

## Verification

- `mvn --errors --batch-mode clean install -Pqulice` passes locally on JDK 21 with no errors and no qulice violations.
- All 10 CI checks (mvn on ubuntu/macos/windows + actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint) are green on commit `dd937a9`.
