### PR TITLE
fix: #101 guard atomic shutdown hook with locked flag

### DIFF
--- a/src/main/java/co/stateful/Atomic.java
+++ b/src/main/java/co/stateful/Atomic.java
@@ -122,6 +122,9 @@ public final class Atomic<T> implements Callable<T> {
     public T call() throws Exception {
         final Thread hook = new Thread(
             () -> {
+                if (!this.locked.get()) {
+                    return;
+                }
                 try {
                     this.lock.unlock(this.label);
                 } catch (final IOException ex) {


### PR DESCRIPTION
Fixes the spurious unlock at JVM shutdown described in #101. When the shutdown hook is installed before the acquisition loop reports success, a JVM exit during the wait — or an exception thrown by `lock()` or `sleep()` before `this.locked.set(true)` — used to call `this.lock.unlock(this.label)` for a lock that was never held; with the default empty label that release could match another holder on the server.

The fix in `src/main/java/co/stateful/Atomic.java` guards the hook body with an early `if (!this.locked.get())` return, so the hook short-circuits whenever the acquisition step did not flip the flag. Successful `call()` paths still unlock through the existing `finally` block and remove the hook there, so behaviour for held locks is unchanged.

Ran `mvn --batch-mode --errors clean install -Pqulice -DskipITs=true` against the change: build succeeded, every unit test under `src/test/java/co/stateful` passed, and Qulice's quality gate completed without new findings.

Closes #101
