### PR TITLE
Fix Atomic lock README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,15 +42,14 @@ Here is how you can use a lock:
 ```java
 Locks locks = sttc.locks();
 Lock lock = locks.get("test-lock");
-new Atomic(lock).call(
-  new Callable<Void>() {
-    @Override
-    public void call() {
-      // perfectly synchronized code
-      return null;
-    }
+Callable<Void> work = new Callable<Void>() {
+  @Override
+  public Void call() {
+    // perfectly synchronized code
+    return null;
   }
-);
+};
+new Atomic<>(work, lock).call();
 ```
 
 ## How to Contribute


### PR DESCRIPTION
Fixes #113.

Updates the README lock example to pass the `Callable` to `Atomic` and invoke its no-argument `call()` method, matching the current API.

Verification:
- `mvn --errors --batch-mode clean install -Pqulice` (JDK 21)
- `markdownlint-cli2 README.md`
